### PR TITLE
Fix inconsistent python/pip invocation in carat.command

### DIFF
--- a/carat.command
+++ b/carat.command
@@ -108,7 +108,7 @@ source .venv/bin/activate
 # ---------------------------------------------------------
 if [ ! -f ".venv/installed.marker" ]; then
     echo "[*] Installing Python libraries..."
-    pip install -q -r requirements.txt
+    pip3 install -q -r requirements.txt
     if [ $? -eq 0 ]; then
         touch .venv/installed.marker
     else
@@ -124,7 +124,7 @@ fi
 echo "[*] Launching Carat..."
 
 # Launch in background, suppressing output
-nohup python src/carat_gui.py >/dev/null 2>&1 &
+nohup python3 src/carat_gui.py >/dev/null 2>&1 &
 
 # Force Terminal.app to close the active window, ignoring errors
 # (in case they somehow launched this from iTerm2)


### PR DESCRIPTION
The script was invoking `python3` in some places but using `pip` and `python` later. On systems where `pip` maps to Python 2 (or a different interpreter than `python3`), this caused dependencies to be installed into a different environment than the one used to run the app.

This change standardizes interpreter usage:

* `pip` → `pip3`
* `python` → `python3`

Now dependency installation and application launch both target the same Python 3 interpreter, preventing environment mismatches and runtime import errors.

Scope is limited to `carat.command`. No behavior changes beyond interpreter consistency.
